### PR TITLE
Rely on hardcoded defaults in engine.rb instead of metadata.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .bundle/
+config/metadata.yml
 log/*.log
 pkg/
 test/dummy/db/*.sqlite3

--- a/config/metadata.yml
+++ b/config/metadata.yml
@@ -1,4 +1,0 @@
----
-version: '6.13.000'
-documentation_server: 'https://access.redhat.com'
-documentation_version: '6.13'

--- a/foreman_theme_satellite.gemspec
+++ b/foreman_theme_satellite.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.summary     = 'This is a plugin that enables building a theme for Foreman.'
   # also update locale/gemspec.rb
   s.description = 'Theme changes for Satellite 6.'
-  s.files = Dir['{app,config,db,lib,locale,webpack}/**/*'] +
+  s.files = Dir['{app,db,lib,locale,webpack}/**/*'] +
             ['LICENSE', 'Rakefile', 'README.md'] +
             ['package.json']
 

--- a/lib/foreman_theme_satellite/engine.rb
+++ b/lib/foreman_theme_satellite/engine.rb
@@ -121,11 +121,11 @@ module ForemanThemeSatellite
     metadata_path = Rails.env.production? ? METADATA_PATH : "#{__dir__}/../../config/metadata.yml"
 
     @metadata_yaml ||= File.exist?(metadata_path) ? YAML.load_file(metadata_path) : {}
-    @metadata_yaml[key] || default
+    @metadata_yaml.fetch(key, default)
   end
 
   def self.get_satellite_version
-    metadata_field('version', '0.0.0-development')
+    metadata_field('version', '6.13.0-development')
   end
 
   def self.get_satellite_short_version


### PR DESCRIPTION
The documentation fields are already correct, so the only change is that the version is now loaded from the engine file. It is changed to have a -development suffix. The file is still loaded in non-production setups so CI or developers can easily override this. Because of that, it's not ignored by git.

The primary motivation for this is avoiding to ship it in packaging.