### PR TITLE
also prepend ThemeCssClassHelper to Katello::LayoutHelper

### DIFF
--- a/lib/foreman_theme_satellite/engine.rb
+++ b/lib/foreman_theme_satellite/engine.rb
@@ -93,6 +93,7 @@ module ForemanThemeSatellite
           Katello::Ping.send :include, SatellitePackages
           Katello::Glue::Provider.send :include, DistributorVersion
           Katello::LayoutHelper.send :include, ThemeLayoutHelper
+          Katello::LayoutHelper.send :prepend, ThemeCssClassHelper
         end
 
         if defined?(ForemanRhCloud)


### PR DESCRIPTION
This fixes the Katello Sync Status (`/katello/sync_management`) page being half-themed, as it, for some reason, does not load Foreman's Helper, only Katello's.