### PR TITLE
Add lifecycle page link to eol banner

### DIFF
--- a/app/assets/stylesheets/foreman_theme_satellite/theme.scss
+++ b/app/assets/stylesheets/foreman_theme_satellite/theme.scss
@@ -21,7 +21,7 @@
   &.eol-banner {
     --banner-height: calc(
       2 * var(--pf-global--spacer--xs) +
-        (var(--pf-global--LineHeight--md) * var(--pf-global--FontSize--sm))
+        2 * (var(--pf-global--LineHeight--md) * var(--pf-global--FontSize--sm))
     ); // banner height is line height and a small padding
     top: calc(
       var(--header-height) + var(--banner-height)

--- a/app/overrides/layouts/base/eol_banner.html.erb.deface
+++ b/app/overrides/layouts/base/eol_banner.html.erb.deface
@@ -3,19 +3,26 @@
 <% if User.current&.admin %>
 <% data = ForemanThemeSatellite.lifecycle_data %>
 
-<% text, icon = if data[:end_of_life].nil?
-   [nil, nil]
+<% text, icon, date = if data[:end_of_life].nil?
+   [nil, nil, nil]
 elsif data[:end_of_life] < Time.zone.now
-   [_('Satellite %{version} is estimated to have reached its End of Life on %{date}.'), 'danger']
+   [_('Satellite %{version} is estimated to have reached its End of Life on %{date}.'), 'danger', data[:end_of_life]]
 elsif data[:end_of_life] < 6.months.after
-   [_('Satellite %{version} is estimated to reach its End of Life on %{date}.'), 'warning']
+   [_('Satellite %{version} is estimated to reach its End of Life by the end of %{month} %{year}.'), 'warning', I18n.l(data[:end_of_life], format: "%B %Y")]
 end %>
 
 <% if text %>
 <div class="pf-c-banner pf-m-<%= icon %>" id="satellite-eol-banner">
   <div>
-    <%= text % { date: data[:end_of_life].to_date, version: data[:current_version] } %>
+    <% if icon == 'warning' %>
+      <%= text % { month: _(data[:end_of_life].strftime('%B')), year: data[:end_of_life].strftime('%Y'), version: data[:short_version] } %>
+    <% else %>
+      <%= text % { date: data[:end_of_life].to_date, version: data[:short_version] } %>
+    <% end %>
+    <div>
+    <%= _("For up to date information about Satellite's lifecycle see ") %><a href="https://access.redhat.com/support/policy/updates/satellite"><%= _("Red Hat Satellite Product Life Cycle") %></a>.
     <%= _("Kindly plan to upgrade Satellite to the supported version, for upgrade guidance see ") %><a href="<%= ForemanThemeSatellite.documentation_server %>/labsinfo/satelliteupgradehelper "><%= _("Red Hat Satellite Upgrade Helper") %>.
+    </div>
   </div>
   <span id="satellite-oel-banner-dismiss-button" style="position: absolute; font-size: 20px; top: 0px; right: 5px; cursor: pointer;">&times;</span>
 </div>

--- a/app/services/foreman_theme_satellite/lifecycle.rb
+++ b/app/services/foreman_theme_satellite/lifecycle.rb
@@ -5,16 +5,15 @@ module ForemanThemeSatellite
       def lifecycle_data(version)
         metadata_path = ::ForemanThemeSatellite::LIFECYCLE_METADATA_PATH
 
-        lifecycle_data = { current_version: version }
+        parsed = Foreman::Version.new(version)
+        lifecycle_data = { current_version: version, short_version: "#{parsed.major}.#{parsed.minor}" }
 
         return lifecycle_data unless File.exist?(metadata_path)
 
-        version = Foreman::Version.new(version)
-
         yaml = YAML.load_file(metadata_path)
-        raise "Unexpected lifecycle metadata file version '#{version}'" unless yaml['version'] == '1'
+        raise "Unexpected lifecycle metadata file version '#{yaml['version']}'" unless yaml['version'] == '1'
 
-        eol = yaml['releases'].fetch("#{version.major}.#{version.minor}", {})['end_of_life']
+        eol = yaml['releases'].fetch(lifecycle_data[:short_version], {})['end_of_life']
         lifecycle_data[:end_of_life] = Time.find_zone('UTC').parse(eol) if eol
         lifecycle_data[:status] = if lifecycle_data[:end_of_life].nil?
                                     nil

--- a/test/unit/lifecycle_test.rb
+++ b/test/unit/lifecycle_test.rb
@@ -4,8 +4,8 @@ class LifecycleTest < ActiveSupport::TestCase
   test "gracefully accepts non-existing metadata" do
     ForemanThemeSatellite.send(:const_set, 'LIFECYCLE_METADATA_PATH', theme_fixture_file('lifecycle-metadata-nope.yml'))
 
-    lifecycle_data = ForemanThemeSatellite::Lifecycle.lifecycle_data('something')
-    expected = { current_version: 'something' }
+    lifecycle_data = ForemanThemeSatellite::Lifecycle.lifecycle_data('25.17.1234-alpha')
+    expected = { current_version: '25.17.1234-alpha', short_version: '25.17' }
 
     assert_equal expected, lifecycle_data
   end


### PR DESCRIPTION
The banner was getting a bit crowded so I turned it into two lines

![image](https://github.com/RedHatSatellite/foreman_theme_satellite/assets/7326770/0da6b1e8-44ed-4fb2-8033-8ffac85ae8f4)

