### PR TITLE
Add failsafe to EOL banner class

### DIFF
--- a/app/overrides/layouts/base/eol_banner.html.erb.deface
+++ b/app/overrides/layouts/base/eol_banner.html.erb.deface
@@ -38,14 +38,20 @@ end %>
   } else {
     window.onload = function(e) {
       // We have to do it from a callback because the element may not exist yet
-      document.getElementById('rails-app-content').classList.add('eol-banner');
+      const railsContainer = document.getElementById('rails-app-content');
+      if (railsContainer) {
+        railsContainer.classList.add('eol-banner');
+      }
     }
   }
 
   const dismissButton = document.getElementById('satellite-oel-banner-dismiss-button');
   dismissButton.addEventListener('click', () => {
       element.style.display = 'none';
-      document.getElementById('rails-app-content').classList.remove('eol-banner');
+      const railsContainer = document.getElementById('rails-app-content');
+      if (railsContainer) {
+        railsContainer.classList.remove('eol-banner');
+      }
       localStorage.setItem('satellite-eol-banner-dismissed', level);
       const now = new Date();
       const cutoff = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);


### PR DESCRIPTION
Technically foreman should remove `#rails-app-content` in some cases.
Currently its not actually happening, so the EOL banner works fine.
It will be fixed when webpack 5 PR is merged.
https://github.com/theforeman/foreman/blob/2c4139e9bee10eac182cadb0e59346f9034f7385/webpack/assets/javascripts/react_app/routes/RoutingService.js#L56