### PR TITLE
Add scrollbar to read eol banner

### DIFF
--- a/app/assets/stylesheets/foreman_theme_satellite/theme.scss
+++ b/app/assets/stylesheets/foreman_theme_satellite/theme.scss
@@ -13,6 +13,10 @@
   }
 }
 
+#satellite-eol-banner .eol-banner-content {
+  overflow-x: auto;
+}
+
 #rails-app-content {
   --header-height: 70px;
   top: var(--header-height);

--- a/app/overrides/layouts/base/eol_banner.html.erb.deface
+++ b/app/overrides/layouts/base/eol_banner.html.erb.deface
@@ -19,7 +19,7 @@ end %>
     <% else %>
       <%= text % { date: data[:end_of_life].to_date, version: data[:short_version] } %>
     <% end %>
-    <div>
+    <div class="eol-banner-content">
     <%= _("For up to date information about Satellite's lifecycle see ") %><a href="https://access.redhat.com/support/policy/updates/satellite"><%= _("Red Hat Satellite Product Life Cycle") %></a>.
     <%= _("Kindly plan to upgrade Satellite to the supported version, for upgrade guidance see ") %><a href="<%= ForemanThemeSatellite.documentation_server %>/labsinfo/satelliteupgradehelper "><%= _("Red Hat Satellite Upgrade Helper") %>.
     </div>


### PR DESCRIPTION
Text was cut in the middle and could not be read before, now users can scroll the long text on small srceens.
![Screenshot from 2023-12-06 15-34-36](https://github.com/RedHatSatellite/foreman_theme_satellite/assets/30431079/2264954c-0581-4957-b381-730314575398)
