### PR TITLE
Drop SPECIAL_LINKS from documentation

### DIFF
--- a/app/controllers/concerns/documentation_controller_branding.rb
+++ b/app/controllers/concerns/documentation_controller_branding.rb
@@ -12,11 +12,11 @@ module DocumentationControllerBranding
     end
     if url.empty?
       upstream_url = super(section, options)
-      if (upstream_url =~ /redhat.com/)
-        url = upstream_url
-      else
-        url = "#{ForemanThemeSatellite.documentation_root}/administering_red_hat_satellite"
-      end
+      url = if (upstream_url =~ /redhat.com/)
+              upstream_url
+            else
+              "#{ForemanThemeSatellite.documentation_root}/administering_red_hat_satellite"
+            end
     end
     url
   end

--- a/app/controllers/concerns/documentation_controller_branding.rb
+++ b/app/controllers/concerns/documentation_controller_branding.rb
@@ -15,9 +15,7 @@ module DocumentationControllerBranding
       if (upstream_url =~ /redhat.com/)
         url = upstream_url
       else
-        special_links_pair = ForemanThemeSatellite::Documentation::SPECIAL_LINKS.find { |regex, _val| regex.match(upstream_url) }
-        url = special_links_pair[1] if special_links_pair
-        url = "#{ForemanThemeSatellite.documentation_root}/administering_red_hat_satellite" if url.empty?
+        url = "#{ForemanThemeSatellite.documentation_root}/administering_red_hat_satellite"
       end
     end
     url

--- a/lib/foreman_theme_satellite/documentation.rb
+++ b/lib/foreman_theme_satellite/documentation.rb
@@ -77,10 +77,6 @@ module ForemanThemeSatellite
       'foreman_discovery' => "#{ForemanThemeSatellite.documentation_root}/provisioning_hosts/configuring_the_discovery_service_provisioning",
     }.freeze
 
-    SPECIAL_LINKS = [
-      [/docs\.theforeman\.org\/.*?\/Managing_Hosts\/.*?registering-a-host.*?managing-hosts/i, "#{ForemanThemeSatellite.documentation_root}/managing_hosts/registering_hosts_to_server_managing-hosts#Registering_Hosts_by_Using_Global_Registration_managing-hosts"],
-    ]
-
     DOCS_GUIDES_LINKS = {
       'Managing_Hosts' => {
         'registering-a-host_managing-hosts' => "#{ForemanThemeSatellite.documentation_root}/managing_hosts/registering_hosts_to_server_managing-hosts#Registering_Hosts_by_Using_Global_Registration_managing-hosts",

--- a/lib/tasks/foreman_theme_satellite_tasks.rake
+++ b/lib/tasks/foreman_theme_satellite_tasks.rake
@@ -44,7 +44,6 @@ namespace :foreman_theme_satellite do
 
     all_links = ForemanThemeSatellite::Documentation::USER_GUIDE_DICTIONARY
                 .merge(ForemanThemeSatellite::Documentation::PLUGINS_DOCUMENTATION)
-                .merge(Hash[ForemanThemeSatellite::Documentation::SPECIAL_LINKS])
                 .merge(ForemanThemeSatellite::Documentation.flat_docs_guides_links)
 
     failed = all_links.filter { |_key, doc_address| doc_address.include?('/html/') && !checker.test_link(doc_address) }


### PR DESCRIPTION
Since https://projects.theforeman.org/issues/32848 the registration link goes through the normal controller.