### PR TITLE
Refs #37632 - Brand content management guide link

### DIFF
--- a/lib/foreman_theme_satellite/documentation.rb
+++ b/lib/foreman_theme_satellite/documentation.rb
@@ -99,9 +99,9 @@ module ForemanThemeSatellite
       source.map do |k, v|
         key = "#{prefix}/#{k}"
         if v.is_a?(Hash)
-          key_values.concat(*nested_to_flat_k_v(key, v))
+          key_values.append(*nested_to_flat_k_v(key, v))
         else
-          key_values.concat([key, v])
+          key_values.append([key, v])
         end
       end
     end

--- a/lib/foreman_theme_satellite/documentation.rb
+++ b/lib/foreman_theme_satellite/documentation.rb
@@ -82,6 +82,9 @@ module ForemanThemeSatellite
     ]
 
     DOCS_GUIDES_LINKS = {
+      'Managing_Content' => {
+        'Products_and_Repositories_content-management' => "#{ForemanThemeSatellite.documentation_root}/managing_content/importing_content_content-management#Products_and_Repositories_content-management",
+      },
       'Managing_Hosts' => {
         'registering-a-host_managing-hosts' => "#{ForemanThemeSatellite.documentation_root}/managing_hosts/registering_hosts_to_server_managing-hosts#Registering_Hosts_by_Using_Global_Registration_managing-hosts",
       }


### PR DESCRIPTION
https://github.com/Katello/katello/pull/11061 starts using this.