### PR TITLE
Change documentation URL to docs.redhat.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Deface::Override.new(:virtual_path  => "about/index",
                      :text          =>  "    <div class=\"stats-well\"><h4><%= _(\"Support\") %></h4> <p>Visit the <%= link_to _('Customer Portal'), \"https://access.redhat.com/\",
                                        :rel => \"external\" %> to get support, find solutions to common questions, and more.</p><h6><%= _(\"Documentation\") %></h6>
                                         <ul>
-                                        <li><%= link_to _('Complete Product Documentation for Red Hat Satellite'),\"https://access.redhat.com/documentation/en/red_hat_satellite/#{ForemanThemeSatellite::SATELLITE_SHORT_VERSION}\", :rel => \"external\" %></li>
+                                        <li><%= link_to _('Complete Product Documentation for Red Hat Satellite'),\"#{ForemanThemeSatellite.documentation_server}/documentation/en/red_hat_satellite/#{ForemanThemeSatellite::SATELLITE_SHORT_VERSION}\", :rel => \"external\" %></li>
                                         <li><%= link_to _('API Resources'), apipie_apipie_path, :title => _('Automate Satellite via a simple and powerful API') %></li>
                                         </ul>
                                         <h6><%= _(\"Blog\") %></h6>

--- a/app/overrides/satellite_name_override.rb
+++ b/app/overrides/satellite_name_override.rb
@@ -37,7 +37,7 @@ Deface::Override.new(:virtual_path  => "about/index",
                      :text          =>  "    <div class=\"stats-well\"><h4><%= _(\"Support\") %></h4> <p>Visit the <%= link_to _('Customer Portal'), \"https://access.redhat.com/\",
                                        :rel => \"external\" %> to get support, find solutions to common questions, and more.</p><h6><%= _(\"Documentation\") %></h6>
                                         <ul>
-                                        <li><%= link_to _('Complete Product Documentation for Red Hat Satellite'),\"https://access.redhat.com/documentation/en/red_hat_satellite/#{ForemanThemeSatellite::SATELLITE_SHORT_VERSION}\", :rel => \"external\" %></li>
+                                        <li><%= link_to _('Complete Product Documentation for Red Hat Satellite'),\"#{ForemanThemeSatellite.documentation_server}/documentation/en/red_hat_satellite/#{ForemanThemeSatellite::SATELLITE_SHORT_VERSION}\", :rel => \"external\" %></li>
                                         <li><%= link_to _('API Resources'), apipie_apipie_path, :title => _('Automate Satellite via a simple and powerful API') %></li>
                                         <li><%= link_to _('Templates DSL'), apipie_dsl_apipie_dsl_path, :title => _('Get DSL reference for templates writing') %></li>
                                         </ul>

--- a/lib/foreman_theme_satellite/engine.rb
+++ b/lib/foreman_theme_satellite/engine.rb
@@ -139,7 +139,7 @@ module ForemanThemeSatellite
   end
 
   def self.documentation_server
-    @documentation_server ||= metadata_field('documentation_server', 'https://access.redhat.com')
+    @documentation_server ||= metadata_field('documentation_server', 'https://docs.redhat.com')
   end
 
   def self.documentation_version

--- a/test/integration/documentation_controller_branding_test.rb
+++ b/test/integration/documentation_controller_branding_test.rb
@@ -4,12 +4,12 @@ class DocumentationControllerBrandingTest < ActionDispatch::IntegrationTest
   def test_docs_redirect_branded
     get "/links/docs/Managing_Hosts?chapter=registering-a-host_managing-hosts"
 
-    assert_redirected_to "https://access.redhat.com/documentation/en-us/red_hat_satellite/#{ForemanThemeSatellite.documentation_version}/html/managing_hosts/registering_hosts_to_server_managing-hosts#Registering_Hosts_by_Using_Global_Registration_managing-hosts"
+    assert_redirected_to "https://docs.redhat.com/documentation/en-us/red_hat_satellite/#{ForemanThemeSatellite.documentation_version}/html/managing_hosts/registering_hosts_to_server_managing-hosts#Registering_Hosts_by_Using_Global_Registration_managing-hosts"
   end
 
   def test_docs_redirect_unknown_chapter
     get "/links/docs/Managing_Hosts"
 
-    assert_redirected_to "https://access.redhat.com/documentation/en-us/red_hat_satellite/#{ForemanThemeSatellite.documentation_version}/html/managing_hosts/"
+    assert_redirected_to "https://docs.redhat.com/documentation/en-us/red_hat_satellite/#{ForemanThemeSatellite.documentation_version}/html/managing_hosts/"
   end
 end


### PR DESCRIPTION
Red Hat has moved its documentation to its own domain. The old links now redirect. This saves the users a redirect.