### PR TITLE
Drop old Katello plugin link branding

### DIFF
--- a/lib/foreman_theme_satellite/branded_words.rb
+++ b/lib/foreman_theme_satellite/branded_words.rb
@@ -53,6 +53,5 @@ module ForemanThemeSatellite
     /\b[Kk]atello 4.11\b(?!-)/       => 'Satellite 6.15',
     /\b[Kk]atello 4.12\b(?!-)/       => 'Satellite 6.16',
     /\b[Kk]atello 4.13\b(?!-)/       => 'Satellite 6.16',
-    %r{https://theforeman.org/plugins/katello/(?!-)} => "https://access.redhat.com/documentation/en-us/red_hat_satellite/#{ForemanThemeSatellite::SATELLITE_SHORT_VERSION}/html/managing_hosts/registering_hosts#registering-a-host-to-satellite-using-the-bootstrap-script"
   }.freeze
 end


### PR DESCRIPTION
This was dropped a few years ago in https://github.com/katello/katello/commit/a2180775a3ca1ca690889400e3fbcf4a41d3976f.