### PR TITLE
Fix documentation hash generation

### DIFF
--- a/lib/foreman_theme_satellite/documentation.rb
+++ b/lib/foreman_theme_satellite/documentation.rb
@@ -95,11 +95,12 @@ module ForemanThemeSatellite
       source.map do |k, v|
         key = "#{prefix}/#{k}"
         if v.is_a?(Hash)
-          key_values.append(*nested_to_flat_k_v(key, v))
+          key_values.concat(nested_to_flat_k_v(key, v))
         else
-          key_values.append([key, v])
+          key_values.concat([[key, v]])
         end
       end
+      key_values
     end
   end
 end


### PR DESCRIPTION
Fix the error in the CI:
```
ArgumentError: wrong array length at 0 (expected 2, was 4)
/home/runner/work/foreman_theme_satellite/foreman_theme_satellite/foreman_theme_satellite/lib/foreman_theme_satellite/documentation.rb:90:in `to_h'
/home/runner/work/foreman_theme_satellite/foreman_theme_satellite/foreman_theme_satellite/lib/foreman_theme_satellite/documentation.rb:90:in `flat_docs_guides_links'
/home/runner/work/foreman_theme_satellite/foreman_theme_satellite/foreman_theme_satellite/lib/tasks/foreman_theme_satellite_tasks.rake:32:in `block (2 levels) in <top (required)>'
```