### PR TITLE
Fix french translation to state Proxy HTTP

### DIFF
--- a/lib/foreman_theme_satellite/branded_words.rb
+++ b/lib/foreman_theme_satellite/branded_words.rb
@@ -10,6 +10,8 @@ module ForemanThemeSatellite
   FOREMAN_BRAND = {
     /%{proxy}/               => '%{proxy}',
     /%{foreman}/             => '%{foreman}',
+    /\b[Pp]roxy [Hh][Tt][Tt][Pp]\b(?!-)/    => 'Proxy HTTP', # Workaround for French translation
+    /\b[Pp]roxies [Hh][Tt][Tt][Pp]\b(?!-)/ => 'Proxies HTTP', # Workaround for French translation
     /\b[Hh][Tt][Tt][Pp] [Pp]roxy\b(?!-)/    => 'HTTP Proxy',
     /\b[Hh][Tt][Tt][Pp] [Pp]roxies\b(?!-)/ => 'HTTP Proxies',
     /\bHTTP\(S\) proxy\b(?!-)/ => 'HTTP(S) proxy',


### PR DESCRIPTION
By default it is translated and branded to `Capsule HTTP` which is not correct.
This stems from the fact that the theme assumes branded words always appear in the same order. In this specific case, the assumption is broken.
This is a workaround until we find a better way to deal with translations and branding