### PR TITLE
Replace angular translation before its used

### DIFF
--- a/app/views/foreman_theme_satellite/_theme_client_side_branding.js.erb
+++ b/app/views/foreman_theme_satellite/_theme_client_side_branding.js.erb
@@ -31,33 +31,43 @@ tfm.i18n.jed.dcnpgettext = function( domain, context, singular_key, plural_key, 
   return brand_string(translated);
 }
 
-if (typeof(angular) !== 'undefined') {
-  angular.module('Bastion.i18n').config([ '$provide', function($provide) {
-    $provide.decorator('translate', [
-      '$delegate',
-      function ($delegate) {
-        var originalTranslate = $delegate;
-        return function(str) {
-          originalStr = originalTranslate(str);
-          return brand_string(originalStr);
-        }
-      }
+document.addEventListener("loadAngularJSi18n", function () {
+  if (typeof angular !== "undefined") {
+    angular.module("Bastion.i18n").config([
+      "$provide",
+      function ($provide) {
+        $provide.decorator("translate", [
+          "$delegate",
+          function ($delegate) {
+            var originalTranslate = $delegate;
+            return function (str) {
+              originalStr = originalTranslate(str);
+              return brand_string(originalStr);
+            };
+          },
+        ]);
+      },
     ]);
-  }]);
-}
+  }
+});
 
-if (typeof(angular) !== 'undefined') {
-  angular.module('gettext').config([ '$provide', function($provide) {
-    $provide.decorator('gettextCatalog', [
-      '$delegate',
-      function ($delegate) {
-        var originalTranslate = $delegate.getString;
-        $delegate.getString = function(str) {
-          originalStr = originalTranslate.apply($delegate, [str]);
-          return brand_string(originalStr);
-        }
-        return $delegate;
-      }
+document.addEventListener("loadAngularJSgettext", function () {
+  if (typeof angular !== "undefined") {
+    angular.module("gettext").config([
+      "$provide",
+      function ($provide) {
+        $provide.decorator("gettextCatalog", [
+          "$delegate",
+          function ($delegate) {
+            var originalTranslate = $delegate.getString;
+            $delegate.getString = function (str) {
+              originalStr = originalTranslate.apply($delegate, [str]);
+              return brand_string(originalStr);
+            };
+            return $delegate;
+          },
+        ]);
+      },
     ]);
-  }]);
-}
+  }
+});


### PR DESCRIPTION
Needs https://github.com/Katello/katello/pull/11158
Explanation copy from that pr:

The deface for branding needs to happen (from `engines/bastion/app/views/bastion/layouts/assets.html.erb`):
* after angular and i18n, gettext are created: ` <%= javascript_include_tag('bastion/bastion', {type: 'module'})%>`
* and before the first translation is used with `translate(...`, I think its in: `<%= javascript_include_tag('bastion_katello/bastion_katello',  {type: 'module'}) %>`