### PR TITLE
Expose multi-CV feature downstream

### DIFF
--- a/app/models/concerns/setting_branding.rb
+++ b/app/models/concerns/setting_branding.rb
@@ -7,7 +7,7 @@ module SettingBranding
     end
 
     def [](name)
-      if UpstreamOnlySettings::SETTINGS.include?(name.to_s)
+      if UpstreamOnlySettings.include?(name.to_s)
         Rails.logger.debug "Setting '#{name}' is not available in Satellite; ignoring"
         return nil
       end

--- a/app/models/concerns/upstream_only_settings.rb
+++ b/app/models/concerns/upstream_only_settings.rb
@@ -1,6 +1,13 @@
 # Settings to hide in downstream (will return nil for all values)
-module UpstreamOnlySettings
+class UpstreamOnlySettings
   SETTINGS = %w[
-    allow_multiple_content_views
   ].freeze
+
+  def self.include?(key)
+    new.include?(key)
+  end
+
+  def include?(key)
+    SETTINGS.include?(key.to_s)
+  end
 end


### PR DESCRIPTION
This removes `allow_multiple_content_views` from UpstreamOnlySettings, allowing it to be exposed downstream.

I didn't remove the UpstreamOnlySettings feature entirely, because I thought it might be handy to have in the future? thoughts welcome.
