### PR TITLE
Brand smart proxy(ies) to Capsule(s)

### DIFF
--- a/lib/foreman_theme_satellite/foreman_brand.rb
+++ b/lib/foreman_theme_satellite/foreman_brand.rb
@@ -28,6 +28,7 @@ module ForemanThemeSatellite
     /\bperform various actions through those proxies\b(?!-)/ => 'perform various actions through those proxies',
     ## END
     /\b[Ff]oreman\b(?!-)/            => 'Satellite',
+    /\b[Ss]mart[- ]?[Pp]roxy\(ies\)(?!-)/ => 'Capsule(s)',
     /\b[Ss]mart[- ]?[pP]roxy\b(?!-)/ => 'Capsule',
     /\b[Ss]mart[- ]?[pP]roxies\b(?!-)/ => 'Capsules',
     /\b[Pp]roxy\b(?!-)/              => 'Capsule',


### PR DESCRIPTION
The string https://github.com/Katello/katello/blob/1c02a478adceb217c380b3f410e7ed84200f6097/app/lib/actions/katello/repository/capsule_sync.rb#L6 is not branded correctly in Satellite. Also see [31424](https://issues.redhat.com/browse/SAT-31424)