### PR TITLE
Fixes #38676 - Remove unwanted "|" in Edit Capsules page

### DIFF
--- a/lib/foreman_theme_satellite/foreman_brand.rb
+++ b/lib/foreman_theme_satellite/foreman_brand.rb
@@ -29,6 +29,7 @@ module ForemanThemeSatellite
     ## END
     /\b[Ff]oreman\b(?!-)/            => 'Satellite',
     /\b[Ss]mart[- ]?[Pp]roxy\(ies\)(?!-)/ => 'Capsule(s)',
+    /\b[Ss]mart[- ]?[pP]roxy\s*\|\s*/ => 'Capsule ',
     /\b[Ss]mart[- ]?[pP]roxy\b(?!-)/ => 'Capsule',
     /\b[Ss]mart[- ]?[pP]roxies\b(?!-)/ => 'Capsules',
     /\b[Pp]roxy\b(?!-)/              => 'Capsule',


### PR DESCRIPTION
Removed the unwanted "|" in Edit Capsules page of Satellite 6.17.

Testing steps:

1. Install a satellite and capsule 6.17
2. Edit the capsule to change it's download policy 
3. The text for download policy should be Capsule Download Policy