### PR TITLE
SAT-35235 - Remove docs link from upgrades

### DIFF
--- a/webpack/index.js
+++ b/webpack/index.js
@@ -11,7 +11,7 @@ import SatelliteUpgradeHelperCard from './components/fills/UpgradePage/Satellite
 componentRegistry.register({ name: 'Helmet', type: Helmet });
 
 addGlobalFill(
-  'upgrade-page-additional-docs',
+  'upgrade-page-upgrade-docs',
   'Satellite upgrade helper card',
   <SatelliteUpgradeHelperCard key="satellite-upgrade-helper-card" />,
   1000,


### PR DESCRIPTION
It's one of the possible fixes for the issue, more lightweight.

Another solution would be removing the page altogether from Foreman and moving needed bits here instead.