### PR TITLE
Fixes SAT-40426 - Removes trailing space on link to upgrade helper

### DIFF
--- a/app/overrides/layouts/base/eol_banner.html.erb.deface
+++ b/app/overrides/layouts/base/eol_banner.html.erb.deface
@@ -21,7 +21,7 @@ end %>
     <% end %>
     <div class="eol-banner-content">
     <%= _("For up to date information about Satellite's lifecycle see ") %><a href="https://access.redhat.com/support/policy/updates/satellite"><%= _("Red Hat Satellite Product Life Cycle") %></a>.
-    <%= _("Kindly plan to upgrade Satellite to the supported version, for upgrade guidance see ") %><a href="https://access.redhat.com/labsinfo/satelliteupgradehelper "><%= _("Red Hat Satellite Upgrade Helper") %>.
+    <%= _("Kindly plan to upgrade Satellite to the supported version, for upgrade guidance see ") %><a href="https://access.redhat.com/labsinfo/satelliteupgradehelper"><%= _("Red Hat Satellite Upgrade Helper") %>.
     </div>
   </div>
   <span id="satellite-oel-banner-dismiss-button" style="position: absolute; font-size: 20px; top: 0px; right: 5px; cursor: pointer;">&times;</span>


### PR DESCRIPTION
The EOL banner includes a link sending the user to the Red Hat Satellite Upgrade Helper. This link is broken because of a trailing space at the end of the URL.

This PR removes the trailing space and fixes the broken link