### PR TITLE
Reduce CI testing matrix for 15.3-stable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,3 +31,4 @@ jobs:
     with:
       plugin: foreman_theme_satellite
       foreman_version: ${{ matrix.foreman }}
+      matrix_exclude: '[{"ruby": "2.7"}, {"node": "22"}]'


### PR DESCRIPTION
Currently it runs with various combinations of ruby 2.7 and 3.0 and nodejs 18 and 22. Leading to many (19 here, 39 in https://github.com/RedHatSatellite/foreman_theme_satellite/pull/285) checks being spawned. Limiting everything to ruby 3.0 and nodejs 18 (ie. what we run and build Satellite 6.18 with) shouldn't hurt anything