### PR TITLE
Fixes SAT-41301 - EOL banner hides top part of page

### DIFF
--- a/app/assets/stylesheets/foreman_theme_satellite/theme.scss
+++ b/app/assets/stylesheets/foreman_theme_satellite/theme.scss
@@ -17,20 +17,10 @@
   overflow-x: auto;
 }
 
-#rails-app-content {
-  --header-height: 70px;
-  top: var(--header-height);
-  height: calc(100% - var(--header-height));
-
-  &.eol-banner {
-    --banner-height: calc(
-      2 * var(--pf-v5-global--spacer--xs) +
-        2 * (var(--pf-v5-global--LineHeight--md) * var(--pf-v5-global--FontSize--sm))
-    ); // banner height is line height and a small padding
-    top: calc(
-      var(--header-height) + var(--banner-height)
-    );
-
-    height: calc(100% - var(--header-height) - var(--banner-height));
-  }
+body.eol-banner-present {
+  --eol-banner-height: calc(
+    2 * var(--pf-v5-global--spacer--xs) + 2 *
+      (var(--pf-v5-global--LineHeight--md) * var(--pf-v5-global--FontSize--sm))
+  ); // banner height is line height and a small padding
+  --header-height: (70px + var(--eol-banner-height));
 }

--- a/app/overrides/layouts/base/eol_banner.html.erb.deface
+++ b/app/overrides/layouts/base/eol_banner.html.erb.deface
@@ -38,9 +38,9 @@ end %>
   } else {
     window.onload = function(e) {
       // We have to do it from a callback because the element may not exist yet
-      const railsContainer = document.getElementById('rails-app-content');
-      if (railsContainer) {
-        railsContainer.classList.add('eol-banner');
+      const body = document.body;
+      if (body) {
+        body.classList.add('eol-banner-present');
       }
     }
   }
@@ -48,9 +48,9 @@ end %>
   const dismissButton = document.getElementById('satellite-oel-banner-dismiss-button');
   dismissButton.addEventListener('click', () => {
       element.style.display = 'none';
-      const railsContainer = document.getElementById('rails-app-content');
-      if (railsContainer) {
-        railsContainer.classList.remove('eol-banner');
+      const body = document.body
+      if (body) {
+        body.classList.remove('eol-banner-present');
       }
       localStorage.setItem('satellite-eol-banner-dismissed', level);
       const now = new Date();


### PR DESCRIPTION
Fixes 2 issues:
1. adjusts the height of notifications container by setting the header height to include the eol banner
2. fixes a new issue that was created in https://github.com/theforeman/foreman/pull/10863 that accidentally overrode the `--banner-height`  by using the same name 