### PR TITLE
Make link checker accept auxiliary IDs (#320)

### DIFF
--- a/lib/tasks/foreman_theme_satellite_tasks.rake
+++ b/lib/tasks/foreman_theme_satellite_tasks.rake
@@ -21,9 +21,14 @@ namespace :foreman_theme_satellite do
       toc_file = File.expand_path('../../test/fixtures/toc.json', __dir__)
       puts "Using default TOC: #{toc_file}, to override please specify TOC=<toc_file>"
     end
+    aliases_file = ENV['ALIASES']
+    unless aliases_file
+      aliases_file = File.expand_path('../../test/fixtures/aliases.json', __dir__)
+      puts "Using default ALIASES: #{aliases_file}, to override please specify ALIASES=<aliases_file>"
+    end
 
     require_relative '../../test/link_checker'
-    checker = LinksChecker.new(toc: toc_file)
+    checker = LinksChecker.new(toc: toc_file, aliases: aliases_file)
 
     require_relative '../foreman_theme_satellite/documentation'
 

--- a/test/link_checker.rb
+++ b/test/link_checker.rb
@@ -2,8 +2,12 @@ require 'json'
 require 'uri'
 
 class LinksChecker
-  def initialize(toc:)
+  def initialize(toc:, aliases: nil)
     @toc = JSON.parse(File.read(toc))
+    @aliases = {}
+
+    return unless aliases && File.exist?(aliases)
+    @aliases = JSON.parse(File.read(aliases)).to_h { |k, vs| [k.downcase, vs.map(&:downcase)] }
   end
 
   def test_link(url)
@@ -11,7 +15,12 @@ class LinksChecker
 
     return false unless doc_path
 
-    chapters = @toc[doc_path]
+    chapters = case_insensitive_lookup(@toc, doc_path)
+    if chapters.nil?
+      doc_path = guide_alias(doc_path)
+      return false if doc_path.nil?
+      chapters = case_insensitive_lookup(@toc, doc_path)
+    end
 
     return false if chapters.nil? # no such page
     return true if anchor.nil? # the page exists, no particular anchor means we want just the page
@@ -19,9 +28,9 @@ class LinksChecker
     # Even though the ToC generated with html-multi in mind,
     # we can't properly dig due to html-single using anchors on index page for the whole section
     # dropping the intermediate path
-    page = chapters.keys.map(&:downcase) + chapters.values.flatten.map(&:downcase)
+    pages = chapters.keys.map(&:downcase) + chapters.values.flatten.map(&:downcase)
 
-    page.include?(anchor.downcase)
+    pages.include?(anchor.downcase) || pages.include?(guide_anchor_aliases(doc_path, anchor))
   end
 
   private
@@ -37,5 +46,29 @@ class LinksChecker
     anchor = uri.fragment
 
     [doc_path, anchor]
+  end
+
+  def guide_alias(guide)
+    k, _v = @aliases.find { |_k, vs| vs.include? guide.downcase }
+
+    return if k.nil?
+
+    k
+  end
+
+  def guide_anchor_aliases(guide, anchor)
+    k, _v = @aliases.find do |_k, aliases|
+      re = %r{^#{Regexp.escape(guide)}/.*##{Regexp.escape(anchor)}$}
+      aliases.any? { |a| a =~ re }
+    end
+
+    k&.split('#')&.last
+  end
+
+  def case_insensitive_lookup(hash, key)
+    return hash[key] if hash[key]
+
+    _, v = hash.find { |k, _| k.casecmp(key).zero? }
+    v
   end
 end

--- a/test/unit/link_checker_test.rb
+++ b/test/unit/link_checker_test.rb
@@ -1,0 +1,107 @@
+require 'test_plugin_helper'
+require 'tempfile'
+require_relative '../link_checker'
+
+# Structure mirrors the real toc.json (no aliases key; aliases live in a separate file)
+MINIMAL_TOC = {
+  "some_guide" => {
+    "new-chapter" => [
+      "new-anchor",
+    ],
+    "chapter-with-subs" => [
+      "sub-anchor-one",
+      "Sub_Anchor_Mixed_Case",
+    ],
+  },
+}.freeze
+
+# Aliases live in a separate file, mirroring the real aliases.json
+MINIMAL_ALIASES = {
+  # anchor-level alias: the old anchor "old-anchor" (inside new-chapter) is now
+  # "new-anchor" (inside new-chapter). A link to #old-anchor should be accepted.
+  "some_guide/new-chapter#new-anchor" => [
+    "some_guide/new-chapter#old-anchor",
+  ],
+  # section-level alias: the new section "new-chapter" is the canonical; "old-chapter" is an alias
+  "some_guide/new-chapter" => [
+    "some_guide/old-chapter",
+  ],
+  # guide-level alias: some_guide is the canonical; old_guide_name is an alias
+  "some_guide" => [
+    "old_guide_name",
+  ],
+}.freeze
+
+class LinkCheckerTest < ActiveSupport::TestCase
+  def setup
+    @toc_file = Tempfile.new(['toc', '.json'])
+    @toc_file.write(JSON.dump(MINIMAL_TOC))
+    @toc_file.close
+
+    @aliases_file = Tempfile.new(['aliases', '.json'])
+    @aliases_file.write(JSON.dump(MINIMAL_ALIASES))
+    @aliases_file.close
+
+    @checker = LinksChecker.new(toc: @toc_file.path, aliases: @aliases_file.path)
+
+    @toc_file.unlink
+    @aliases_file.unlink
+  end
+
+  test "valid guide without anchor is valid" do
+    assert @checker.test_link("some_guide/index")
+  end
+
+  test "non-existent guide is invalid" do
+    assert_not @checker.test_link("nonexistent_guide/index")
+  end
+
+  test "valid guide with valid top-level chapter anchor is valid" do
+    assert @checker.test_link("some_guide/index#new-chapter")
+  end
+
+  test "valid guide with invalid anchor is invalid" do
+    assert_not @checker.test_link("some_guide/index#nonexistent-anchor")
+  end
+
+  test "guide and anchor matching is case-insensitive" do
+    assert @checker.test_link("some_guide/index")
+    assert @checker.test_link("SoMe_gUIDE/index")
+    assert @checker.test_link("some_guide/index#sub_anchor_mixed_case")
+    assert @checker.test_link("some_guide/index#SUB_ANCHOR_MIXED_CASE")
+    assert @checker.test_link("SoMe_gUIDE/index#sub_anchor_mixed_case")
+    assert @checker.test_link("SoMe_gUIDE/index#SUB_ANCHOR_MIXED_CASE")
+  end
+
+  test "old anchor resolves to new anchor via alias" do
+    # The alias maps: some_guide/new-chapter#new-anchor <- some_guide/old-chapter#old-anchor
+    # A link pointing to the old anchor should be accepted because the checker
+    # resolves it to the canonical new-anchor, which exists in the TOC.
+    assert @checker.test_link("some_guide/index#old-anchor")
+  end
+
+  test "aliases are transitive" do
+    assert @checker.test_link("old_guide_name/index#old-anchor")
+  end
+
+  test "non-aliased unknown anchor is invalid" do
+    assert_not @checker.test_link("some_guide/index#completely-unknown-anchor")
+  end
+
+  test "old guide name resolves via guide-level alias" do
+    assert @checker.test_link("old_guide_name/index")
+  end
+
+  test "TOC without aliases file does not crash" do
+    toc_without_aliases = Tempfile.new(['toc_no_aliases', '.json'])
+    toc_without_aliases.write(JSON.dump("some_guide" => { "a-chapter" => [] }))
+    toc_without_aliases.close
+
+    checker = LinksChecker.new(toc: toc_without_aliases.path, aliases: nil)
+    assert checker.test_link("some_guide/index")
+    assert checker.test_link("some_guide/index#a-chapter")
+    assert_not checker.test_link("some_guide/index#missing")
+  ensure
+    toc_without_aliases.unlink
+  end
+end


### PR DESCRIPTION
* Make link checker accept auxiliary IDs

* Make all matching case-insensitive

* Accept aliases in a separate file

* Drop configured redirect checking

* Address review comments

(cherry picked from commit d5a6e925e757dcc7d2b4cf7c42510035e0bf101e)
