### PR TITLE
Add downstream docs mapping for Inventory Upload documentation link

### DIFF
--- a/lib/foreman_theme_satellite/documentation.rb
+++ b/lib/foreman_theme_satellite/documentation.rb
@@ -69,11 +69,11 @@ module ForemanThemeSatellite
         'Products_and_Repositories_content-management' => "managing_content/index#Products_and_Repositories_content-management",
       },
       'Managing_Hosts' => {
+        'configuring-foreman-server-for-cloud-connection' => "administering_red_hat_satellite/index#configuring-satellite-server-for-cloud-connection",
         'creating-a-job-template_managing-hosts' => "managing_hosts/index#creating-a-job-template-by-using-web-ui",
         'executing-a-remote-job_managing-hosts' => "managing_hosts/index#Remote-Execution-in-Satellite_managing-hosts",
         'registering-a-host_managing-hosts' => "managing_hosts/index#registering-hosts-by-using-global-registration",
         'setting-minimal-data-collection' => "administering_red_hat_satellite/index#data-control-settings-for-hosted-red-hat-lightspeed",
-        'configuring-foreman-server-for-cloud-connection' => "managing_hosts/index#configuring-satellite-server-for-cloud-connection",
       },
       'Managing_Configurations_Ansible' => {
         'Importing_Ansible_Roles_and_Variables_ansible' => "managing_configurations_by_using_ansible_integration/index#Importing_Ansible_Roles_and_Variables_ansible",

--- a/lib/foreman_theme_satellite/documentation.rb
+++ b/lib/foreman_theme_satellite/documentation.rb
@@ -65,11 +65,13 @@ module ForemanThemeSatellite
     }.freeze
 
     DOCS_GUIDES_LINKS = {
+      'Administering_Project' => {
+        'configuring-foreman-server-for-cloud-connection' => "administering_red_hat_satellite/index#configuring-satellite-server-for-cloud-connection",
+      },
       'Managing_Content' => {
         'Products_and_Repositories_content-management' => "managing_content/index#Products_and_Repositories_content-management",
       },
       'Managing_Hosts' => {
-        'configuring-foreman-server-for-cloud-connection' => "administering_red_hat_satellite/index#configuring-satellite-server-for-cloud-connection",
         'creating-a-job-template_managing-hosts' => "managing_hosts/index#creating-a-job-template-by-using-web-ui",
         'executing-a-remote-job_managing-hosts' => "managing_hosts/index#Remote-Execution-in-Satellite_managing-hosts",
         'registering-a-host_managing-hosts' => "managing_hosts/index#registering-hosts-by-using-global-registration",

--- a/lib/foreman_theme_satellite/documentation.rb
+++ b/lib/foreman_theme_satellite/documentation.rb
@@ -73,6 +73,7 @@ module ForemanThemeSatellite
         'executing-a-remote-job_managing-hosts' => "managing_hosts/index#Remote-Execution-in-Satellite_managing-hosts",
         'registering-a-host_managing-hosts' => "managing_hosts/index#registering-hosts-by-using-global-registration",
         'setting-minimal-data-collection' => "administering_red_hat_satellite/index#data-control-settings-for-hosted-red-hat-lightspeed",
+        'configuring-foreman-server-for-cloud-connection' => "managing_hosts/index#configuring-satellite-server-for-cloud-connection",
       },
       'Managing_Configurations_Ansible' => {
         'Importing_Ansible_Roles_and_Variables_ansible' => "managing_configurations_by_using_ansible_integration/index#Importing_Ansible_Roles_and_Variables_ansible",

--- a/test/integration/documentation_controller_branding_test.rb
+++ b/test/integration/documentation_controller_branding_test.rb
@@ -8,7 +8,7 @@ class DocumentationControllerBrandingTest < ActionDispatch::IntegrationTest
   end
 
   def test_docs_redirect_inventory_upload_documentation
-    get "/links/docs/Managing_Hosts?chapter=configuring-foreman-server-for-cloud-connection"
+    get "/links/docs/Administering_Project?chapter=configuring-foreman-server-for-cloud-connection"
 
     assert_redirected_to "https://docs.redhat.com/documentation/en-us/red_hat_satellite/#{ForemanThemeSatellite.documentation_version}/html-single/administering_red_hat_satellite/index#configuring-satellite-server-for-cloud-connection"
   end

--- a/test/integration/documentation_controller_branding_test.rb
+++ b/test/integration/documentation_controller_branding_test.rb
@@ -7,6 +7,12 @@ class DocumentationControllerBrandingTest < ActionDispatch::IntegrationTest
     assert_redirected_to "https://docs.redhat.com/documentation/en-us/red_hat_satellite/#{ForemanThemeSatellite.documentation_version}/html-single/managing_hosts/index#registering-hosts-by-using-global-registration"
   end
 
+  def test_docs_redirect_inventory_upload_documentation
+    get "/links/docs/Managing_Hosts?chapter=configuring-foreman-server-for-cloud-connection"
+
+    assert_redirected_to "https://docs.redhat.com/documentation/en-us/red_hat_satellite/#{ForemanThemeSatellite.documentation_version}/html-single/managing_hosts/index#configuring-satellite-server-for-cloud-connection"
+  end
+
   def test_docs_redirect_unknown_chapter
     get "/links/docs/Managing_Hosts"
 

--- a/test/integration/documentation_controller_branding_test.rb
+++ b/test/integration/documentation_controller_branding_test.rb
@@ -10,7 +10,7 @@ class DocumentationControllerBrandingTest < ActionDispatch::IntegrationTest
   def test_docs_redirect_inventory_upload_documentation
     get "/links/docs/Managing_Hosts?chapter=configuring-foreman-server-for-cloud-connection"
 
-    assert_redirected_to "https://docs.redhat.com/documentation/en-us/red_hat_satellite/#{ForemanThemeSatellite.documentation_version}/html-single/managing_hosts/index#configuring-satellite-server-for-cloud-connection"
+    assert_redirected_to "https://docs.redhat.com/documentation/en-us/red_hat_satellite/#{ForemanThemeSatellite.documentation_version}/html-single/administering_red_hat_satellite/index#configuring-satellite-server-for-cloud-connection"
   end
 
   def test_docs_redirect_unknown_chapter


### PR DESCRIPTION
## Summary
- Add a `DOCS_GUIDES_LINKS` entry mapping the upstream `configuring-foreman-server-for-cloud-connection` chapter to the Satellite Managing Hosts guide section for cloud connection setup.
- Add an integration test covering the `/links/docs/Managing_Hosts` redirect.

Companion to theforeman/foreman_rh_cloud#1207, which switches the Inventory Upload documentation link to use `getDocsURL` instead of a hardcoded Satellite URL.

## Test plan
- [ ] Click **Documentation** on *Red Hat Lightspeed → Inventory Upload* on Satellite and verify it opens the *Configuring Satellite Server for cloud connection* section in the Managing Hosts guide.
- [ ] Run `bundle exec rake foreman_theme_satellite:validate_docs` and confirm the new link passes the TOC checker.
- [ ] Run `bundle exec ruby -Itest test/integration/documentation_controller_branding_test.rb`.


Made with [Cursor](https://cursor.com)