### PR TITLE
Update topbar css to override foreman

### DIFF
--- a/app/assets/stylesheets/foreman_theme_satellite/topbar.scss
+++ b/app/assets/stylesheets/foreman_theme_satellite/topbar.scss
@@ -1,5 +1,5 @@
 .satellite-theme {
-  .pf-v5-c-page .pf-v5-c-masthead {
+  #foreman-page .pf-v5-c-masthead {
     .pf-v5-c-masthead__brand {
       height: inherit;
     }


### PR DESCRIPTION
change introduced in: https://github.com/theforeman/foreman/pull/10968

I noticed that the topbar css rule wasnt strong enough anymore, so I updated the selector in this repo, to be stronger.
To ensure I didnt miss any other rules, I ran AI to gather any other css changes made in the last month, and then check if its relevant to the css used in this repo.

AI findings:

## Specificity audit vs Foreman CSS changes

Repo CSS surface that can conflict with Foreman: `app/assets/stylesheets/foreman_theme_satellite/{topbar,login,patternfly_and_overrides,application_colors,external_logout,bastion,wizard,provisioning_templates}.scss|css`. No webpack SCSS.

---

### fb3d37d98 — scoped under `#foreman-page` / custom classes

| Foreman change | Relevant? | Proof |
|---|---|---|
| `navigation.scss`: `.pf-v5-c-masthead` → `#foreman-page .pf-v5-c-masthead` | **Yes** | Theme overrides masthead `background` / brand in `topbar.scss`. Old selector `.satellite-theme .pf-v5-c-page .pf-v5-c-masthead` = `(0,3,0)`; Foreman `#foreman-page .pf-v5-c-masthead` = `(1,1,0)` — Foreman won. **Fixed** → `.satellite-theme #foreman-page .pf-v5-c-masthead` = `(1,2,0)`. |
| `layout.scss`: `.pf-v5-c-page` → `#foreman-page` | **Indirect** | Theme never targeted bare `.pf-v5-c-page` for its own rules (only as a parent of masthead in old `topbar.scss`). Same masthead fix covers it. |
| `layout.scss`: `.pf-v5-c-page .pf-v5-c-masthead` → `#foreman-page .pf-v5-c-masthead` | **Yes** | Same colliding property set as navigation (background-size/cover). Covered by the `topbar.scss` fix. |
| `TaxonomyDropdown.scss`: toolbar under masthead | **No** | No matches for `pf-v5-c-toolbar` / taxonomy selectors in this repo’s stylesheets. |
| `TaxonomyDropdown.scss`: `.pf-v5-c-masthead__brand` → `#foreman-page .pf-v5-c-masthead__brand` | **Partial** | Theme sets `__brand { height: inherit }` inside the masthead block. Nested under the fixed `#foreman-page` selector, so it stays ahead. No separate brand-only rule elsewhere. |
| `ImpersonateIcon.scss`: `#foreman-page .pf-v5-c-masthead` | **No** | Theme does not style impersonate icon / that masthead subset. |
| `LoginPage.scss`: `.pf-v5-c-login__footer p` → `#login-page .pf-v5-c-login__footer p` | **No** | Theme never styles `__footer` / `login__footer`. Login overrides use `#login-page .login-pf` / `.login-pf-brand` only (`login.scss`). Already ID-scoped; specificity already beats Foreman’s `#login-page .login-pf`. |
| `column-selector.scss`: `.pf-v5-c-input-group` → `#column-selector` | **No** | No `column-selector` / `input-group` / `manage-columns` CSS in this repo. |
| `column-selector.scss`: modal OUIA selector change | **No** | No modal / `manage-columns-modal` CSS here. |
| `HostDetails.scss`: tabs section class change | **No** | README mentions host-details fills; no SCSS for `.host-details-tabs-section` or related PF page sections. |
| `EmptyState.scss`: `.pf-v5-c-empty-state` → `.foreman-empty-state` | **No** | No empty-state CSS in this repo. |
| `ToastsList`: `.pf-v5-c-alert-group` → `.foreman-toast-group` | **No** | No toast / alert-group CSS. |
| `ActionButtons.scss`: menu-toggle / menu list scoped under `.action-buttons-dropdown` | **No** | No action-buttons CSS. |
| `Pagination`: selector reorder only | **No** | No pagination / `tfm-pagination` CSS. |

---

### a9db7835 — PageLayout class → ID

| Foreman change | Relevant? | Proof |
|---|---|---|
| `.page-layout-title-section` → `#page-layout-title-section` | **No** | Zero `page-layout-*` selectors in this repo. |
| `.page-layout-toolbar-section` → `#page-layout-toolbar-section` | **No** | Same. |
| `.page-layout-content-section` → `#page-layout-content-section` | **No** | Same. |
| `.page-layout-toolbar` → `#page-layout-toolbar` | **No** | Same. |
| `.page-layout-toolbar-search` → `#page-layout-toolbar-search` | **No** | Same. |

---

### Adjacent theme rules (not in Foreman list, but checked)

| Theme rule | Status |
|---|---|
| `login.scss`: `.satellite-theme #login-page …` | Already strong enough vs Foreman `#login-page` rules; no change needed. |
| `patternfly_and_overrides.scss`: `#page-sidebar` | Already ID-scoped; Foreman list did not change sidebar targeting in a way that breaks this. |
| `application_colors.css`: `.login-pf body .login-page` | Legacy class selector; does not collide with the listed `#login-page` footer / PF5 login changes. |

---

### Verdict for PR

**Only relevant breakage:** masthead / brand overrides in `topbar.scss` vs Foreman’s `#foreman-page`-scoped navigation + layout rules.

**Fix shipped:** replace `.pf-v5-c-page .pf-v5-c-masthead` with `#foreman-page .pf-v5-c-masthead` under `.satellite-theme`.

**All other listed Foreman changes:** not applicable — this plugin has no matching selectors.