### PR TITLE
Add link for dependency solving docs

### DIFF
--- a/lib/foreman_theme_satellite/documentation.rb
+++ b/lib/foreman_theme_satellite/documentation.rb
@@ -70,6 +70,7 @@ module ForemanThemeSatellite
       },
       'Managing_Content' => {
         'Products_and_Repositories_content-management' => "managing_content/index#Products_and_Repositories_content-management",
+        'dependency-solving-for-content-views' => "managing_content/index#dependency-solving-for-content-views",
       },
       'Managing_Hosts' => {
         'creating-a-job-template_managing-hosts' => "managing_hosts/index#creating-a-job-template-by-using-web-ui",


### PR DESCRIPTION
Adds a link to the dependency solving docs for https://github.com/Katello/katello/commit/5d06d15ed1edd8ae4b9bb7acdff3f6bc8f1c7989